### PR TITLE
[WIP] feat: add simulationapp-based runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# ROS2 Diffusion Policy Runner Notes
+
+This document describes the ROS2 runner + environment implementation used to
+execute diffusion policy inference, and captures the BaseImageRunner contract
+for future extensions.
+
+## BaseImageRunner contract
+- File: `packages/diffusion_policy/src/diffusion_policy/env_runner/base_image_runner.py`
+- Purpose: minimal runner abstraction used by image-based policies.
+- Interface:
+  - `__init__(output_dir)`: store output directory for logs and artifacts.
+  - `run(policy: BaseImagePolicy) -> Dict`: required entry point for evaluation.
+- Expectation: subclasses own environment lifecycle, policy reset, and the
+  collection of episode metrics or outputs; `run` returns a dict of results.
+
+## ROS2Runner (BaseImageRunner implementation)
+- File: `packages/diffusion_policy/src/diffusion_policy/env_runner/ros2_runner.py`
+- Role: execute a diffusion policy in a ROS2-backed environment and collect
+  episode metrics.
+- Environment creation:
+  - Instantiates `ROS2Environment` with observation stacking (`n_obs_steps`).
+  - Requires `urdf_path` to load the robot model in the environment.
+- Observation processing:
+  - Expects `ROS2Environment.get_obs()` to return stacked observations.
+  - `camera0_rgb` is converted from `[n_steps, H, W, 3]` to
+    `[1, n_steps, 3, H, W]` and cast to float tensor.
+  - All other keys are treated as low-dim arrays and converted to
+    `[1, n_steps, dim]` float tensors.
+- Action execution:
+  - Calls `policy.predict_action()` on the processed tensors.
+  - Uses `action_dict["action"]` with shape `[action_horizon, action_dim]`.
+  - Passes the numpy action array directly to `env.step(action)`.
+- Episode loop:
+  - Resets environment and policy at the start of each episode.
+  - Steps until `done` or `max_steps_per_episode`.
+  - Aggregates `episode_stats` and optional step data.
+- Outputs:
+  - Returns `episode_stats`, `total_episodes`, `avg_episode_length`,
+    `success_rate`, and (optionally) `all_step_data`.
+
+## ROS2Environment details
+- File: `packages/diffusion_policy/src/diffusion_policy/environments/ros2_environment.py`
+- Role: ROS2 interface layer that converts sensor messages into policy-ready
+  observations and executes actions via IK + ROS2 publishers.
+- ROS2 topics:
+  - Subscribes to `rgb_topic`, `joint_states_topic` (Pose), and `gripper_topic`.
+  - Publishes joint commands on `action_topic`.
+  - Publishes gripper commands on `/gripper_command` (note: not `gripper_topic`).
+- Robot model and kinematics:
+  - Loads the URDF with IKPy `Chain.from_urdf_file`.
+  - Uses an `active_joints_mask` for Franka Panda (7 active joints).
+  - Maintains `last_joint_angles` for IK initial guess.
+- Action format (critical):
+  - Expects `action` shaped `[N, 10]` per step, with:
+    - `0:3` position (x, y, z)
+    - `3:9` rotation in 6D representation
+    - `9` gripper width
+  - Converts rotation 6D -> quaternion -> rotation matrix for IK target.
+- Observation format:
+  - `camera0_rgb`: RGB image array (normalized float, H x W x 3).
+  - `robot0_eef_pos`: end-effector position.
+  - `robot0_eef_rot_axis_angle`: rotation in 6D (via `mat_to_rot6d`).
+  - `robot0_gripper_width`: scalar array of gripper width.
+  - `robot0_eef_rot_axis_angle_wrt_start`: rotation relative to the initial pose.
+- Stacking behavior:
+  - Observations are appended to `obs_history`.
+  - `get_obs(n_steps)` stacks the last `n_steps` entries and pads the front
+    with the oldest observation if insufficient history exists.
+
+## Practical guidance for junior developers
+- Ensure `urdf_path` is valid and matches the robot used in ROS2.
+- Validate topic names against your ROS2 setup; message types must match.
+- Confirm policy action dimensions align with `[N, 10]` expectation.
+- If observations are mis-shaped, verify:
+  - ROS image encoding (`rgb8`) and normalization in `_process_raw_observations`.
+  - `image_shape` (default `(3, 224, 224)`) matches the upstream camera output.
+- The environment returns `done=False` and `reward=0.0` by default; success
+  criteria are not implemented in this layer.
+- `ROS2Runner` treats `done` as success; make sure environment or policy sets it
+  if you need meaningful success rates.

--- a/packages/diffusion_policy/src/diffusion_policy/env_runner/base_isaacsim_app_runner.py
+++ b/packages/diffusion_policy/src/diffusion_policy/env_runner/base_isaacsim_app_runner.py
@@ -1,0 +1,180 @@
+import time
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+
+from diffusion_policy.common.pytorch_util import dict_apply
+from diffusion_policy.env_runner.base_image_runner import BaseImageRunner
+from diffusion_policy.policy.base_image_policy import BaseImagePolicy
+
+
+class BaseIsaacSimAppRunner(BaseImageRunner, ABC):
+    """
+    Base runner for Isaac Sim inference with diffusion policies.
+
+    Subclasses should manage environment-specific setup and IK using
+    ArticulationKinematicsSolver as shown in `scripts/launch_isaacsim_workspace.py`.
+    """
+
+    def __init__(
+        self,
+        output_dir: str,
+        sim_config: Dict[str, Any],
+        n_episodes: int = 1,
+        max_steps_per_episode: int = 200,
+        n_obs_steps: int = 2,
+        n_action_steps: int = 1,
+        save_observation_data: bool = False,
+    ):
+        super().__init__(output_dir)
+        from isaacsim import SimulationApp
+
+        self.simulation_app = SimulationApp(sim_config)
+        self.n_episodes = n_episodes
+        self.max_steps_per_episode = max_steps_per_episode
+        self.n_obs_steps = n_obs_steps
+        self.n_action_steps = n_action_steps
+        self.save_observation_data = save_observation_data
+
+    def _process_observation_for_policy(
+        self, obs: Dict[str, np.ndarray]
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Convert environment observations into policy-ready tensors.
+        """
+        policy_obs: Dict[str, torch.Tensor] = {}
+
+        if "camera0_rgb" in obs:
+            rgb_img = obs["camera0_rgb"]
+            if rgb_img.ndim == 4:
+                rgb_img = rgb_img.transpose(0, 3, 1, 2)
+            elif rgb_img.ndim == 3:
+                rgb_img = rgb_img.transpose(2, 0, 1)[None, ...]
+            policy_obs["camera0_rgb"] = (
+                torch.from_numpy(rgb_img).float().unsqueeze(0)
+            )
+
+        for key, value in obs.items():
+            if key == "camera0_rgb":
+                continue
+            policy_obs[key] = torch.from_numpy(value).float().unsqueeze(0)
+
+        return policy_obs
+
+    def reset_env(self) -> Dict[str, np.ndarray]:
+        """
+        Reset the environment and return the initial observation.
+        Subclasses should override with Isaac Sim-specific logic.
+        """
+        raise NotImplementedError()
+
+    def step_env(
+        self, action: np.ndarray
+    ) -> Tuple[Dict[str, np.ndarray], float, bool, Dict[str, Any]]:
+        """
+        Apply an action to the environment and return (obs, reward, done, info).
+        Subclasses should override with Isaac Sim-specific logic.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def is_timeout(self, start_time: float, step_count: int) -> bool:
+        """
+        Return True if the current episode should timeout.
+        """
+
+    @abstractmethod
+    def should_terminate(self, done: bool, info: Dict[str, Any]) -> bool:
+        """
+        Return True if the current episode should terminate early.
+        """
+
+    def run(self, policy: BaseImagePolicy) -> Dict[str, Any]:
+        device = policy.device
+        episode_stats = []
+        all_results = []
+
+        for episode_idx in range(self.n_episodes):
+            if not self.simulation_app.is_running():
+                break
+
+            obs = self.reset_env()
+            policy.reset()
+
+            step_count = 0
+            done = False
+            episode_reward = 0.0
+            episode_start_time = time.time()
+            episode_data = []
+
+            while self.simulation_app.is_running():
+                if step_count >= self.max_steps_per_episode:
+                    break
+                if self.is_timeout(episode_start_time, step_count):
+                    break
+
+                obs_dict = self._process_observation_for_policy(obs)
+                obs_dict = dict_apply(obs_dict, lambda x: x.to(device=device))
+
+                with torch.no_grad():
+                    action_dict = policy.predict_action(obs_dict)
+
+                action = action_dict["action"].detach().cpu().numpy()[0]
+                obs, reward, done, info = self.step_env(action)
+                episode_reward += float(reward)
+
+                if self.save_observation_data:
+                    episode_data.append(
+                        {
+                            "obs": obs_dict,
+                            "action": action,
+                            "reward": reward,
+                            "done": done,
+                            "info": info,
+                        }
+                    )
+
+                step_count += 1
+                self.simulation_app.update()
+
+                if self.should_terminate(done, info):
+                    break
+
+            episode_stats.append(
+                {
+                    "episode_idx": episode_idx,
+                    "episode_length": step_count,
+                    "success": bool(done),
+                    "total_reward": episode_reward,
+                }
+            )
+
+            if self.save_observation_data:
+                all_results.extend(episode_data)
+
+        results = {
+            "episode_stats": episode_stats,
+            "total_episodes": len(episode_stats),
+            "avg_episode_length": float(
+                np.mean([ep["episode_length"] for ep in episode_stats])
+            )
+            if episode_stats
+            else 0.0,
+            "success_rate": float(
+                np.mean([ep["success"] for ep in episode_stats])
+            )
+            if episode_stats
+            else 0.0,
+        }
+
+        if self.save_observation_data:
+            results["all_step_data"] = all_results
+
+        return results
+
+    def close(self) -> None:
+        if self.simulation_app:
+            self.simulation_app.close()
+            self.simulation_app = None


### PR DESCRIPTION
This pull request introduces documentation and a new base class to support running diffusion policy inference in IsaacSim V5.1.0 simulated. 

**Documentation and developer guidance:**

* Added `AGENTS.md` with detailed notes on the `BaseImageRunner` contract, the `ROS2Runner` implementation, and the `ROS2Environment` interface, including practical advice for junior developers working with ROS2-based policy runners.

**Isaac Sim runner abstraction:**

* Added new file `base_isaacsim_app_runner.py` implementing `BaseIsaacSimAppRunner`, an abstract base class for Isaac Sim-based policy evaluation. This class manages simulation lifecycle, observation preprocessing, episode management, and provides extension points for environment-specific logic.
* The new runner class includes methods for observation processing, episode loop management, and hooks for environment reset, step, timeout, and termination, facilitating future extensions for custom Isaac Sim environments.